### PR TITLE
also run on images with no gts

### DIFF
--- a/tidecv/data.py
+++ b/tidecv/data.py
@@ -135,4 +135,4 @@ class Data:
 
     def get(self, image_id: int):
         """Collects all the annotations / detections for that particular image."""
-        return [self.annotations[x] for x in self.images[image_id]["anns"]]
+        return [self.annotations[x] for x in self.images.get(image_id, {}).get("anns", [])]

--- a/tidecv/quantify.py
+++ b/tidecv/quantify.py
@@ -181,7 +181,7 @@ class TIDERun:
     def _run(self):
         """And awaaay we go"""
 
-        for image in self.gt.images:
+        for image in set(self.gt.images).union(self.preds.images):
             x = self.preds.get(image)
             y = self.gt.get(image)
 


### PR DESCRIPTION
Tide was only running on the images contained in the GTS instance (of type Data). We also want to run it on the images in PREDS, even if there are no associated gts annotations (in particular all these preds would become background errors).