### PR TITLE
Add associated id for CLS LOC

### DIFF
--- a/tidecv/errors/main_errors.py
+++ b/tidecv/errors/main_errors.py
@@ -75,8 +75,9 @@ class ClassBoxError(Error):
     )
     short_name = "ClsLoc"
 
-    def __init__(self, pred: dict):
+    def __init__(self, pred: dict, gt: dict):
         self.pred = pred
+        self.gt = gt
 
     def fix(self):
         return None

--- a/tidecv/quantify.py
+++ b/tidecv/quantify.py
@@ -303,7 +303,8 @@ class TIDERun:
                 # A base case to catch uncaught errors
                 # self._add_error(OtherError(pred))
                 # idx is already representing the gt box with highest overlap
-                self._add_error(ClassBoxError(pred))
+                self._add_error(ClassBoxError(pred, ex.gt[idx]))
+                pred["info"]["iou"] = iou
 
         for truth in gt:
             # If the GT wasn't used in matching, meaning it's some kind of false negative


### PR DESCRIPTION
Add an associated TIDE id for boxes of error type ClsLoc to help with explainability (but their oracle is still not fixing them and just removing them)